### PR TITLE
Fixed two incorrect links

### DIFF
--- a/source/howtos/deploy/index.rst
+++ b/source/howtos/deploy/index.rst
@@ -41,7 +41,7 @@ provides several guides in how to deploy your model in different environments.
         Deploy models from external marketplaces (BioImage Model Zoo).
 
     .. grid-item-card:: :fas:`brain;fa-lg sd-mr-2`  Deploy your own LLM
-        :link: external
+        :link: llm
         :link-type: doc
 
         Deploy your own LLM from a selection of open-source models (DeepSeek, Qwen, LLama, etc),

--- a/source/howtos/deploy/oscar-manual.rst
+++ b/source/howtos/deploy/oscar-manual.rst
@@ -71,7 +71,7 @@ OSCAR services can be invoked (see `Invoking services <https://docs.oscar.grycap
 * Examples to `deploy AI models with DEEPaaS support <https://github.com/grycap/oscar/tree/master/examples>`__,
   including:
 
-  - The deployment of the `Body pose detection <https://dashboard.cloud.ai4eosc.eu/marketplace/modules/deep-oc-posenet-tf>`__
+  - The deployment of the `Body pose detection <https://dashboard.cloud.ai4eosc.eu/marketplace/modules/DEEP-OC-posenet-tf>`__
     AI model from the AI4EOSC Marketplace is documented in the `body-pose-detection <https://github.com/grycap/oscar/tree/master/examples/body-pose-detection>`__
     folder, used to perform asynchronous invocations via MinIO.
   - The deployment of the `Plants Species Classifier <https://dashboard.cloud.ai4eosc.eu/marketplace/modules/plants-classification>`__


### PR DESCRIPTION
In [Manually deploy a serverless inference endpoint](https://docs.ai4os.eu/en/latest/howtos/deploy/index.html) the "Body pose detection" link:
- Before:  https://dashboard.cloud.ai4eosc.eu/marketplace/modules/deep-oc-posenet-tf  
- Now: https://dashboard.cloud.ai4eosc.eu/marketplace/modules/DEEP-OC-posenet-tf

In [Deploy a model in production](https://docs.ai4os.eu/en/latest/howtos/deploy/index.html#) the "Deploy your own LLM" link:
- Before:  `:link: external`
- Now:  `:link: llm`