### PR TITLE
add GitHub README links to Elyra and Node-RED pages

### DIFF
--- a/source/howtos/pipelines/elyra.rst
+++ b/source/howtos/pipelines/elyra.rst
@@ -28,6 +28,7 @@ This tutorial will focus on:
 We will walk through the entire process, from setting up the initial environment to
 running specific OSCAR services like the Cowsay and others.
 
+For a complete view of the repository containing these examples, please refer to the `GitHub README <https://github.com/ai4os/ai4-compose/blob/main/elyra/README.md>`__.
 
 1. Setting up the environment
 -----------------------------

--- a/source/howtos/pipelines/flowfuse.rst
+++ b/source/howtos/pipelines/flowfuse.rst
@@ -15,6 +15,8 @@ services with Node-RED & FlowFuse, specifically:
 * how to create our first application and Node-RED instance,
 * how to deploy a workflow to utilize inference services using OSCAR.
 
+For a complete overview of the Node-RED and FlowFuse examples, please refer to the `GitHub README <https://github.com/ai4os/ai4-compose/blob/main/node-red/README.md>`__.
+
 First of all, let's understand what FlowFuse, Node-RED, OSCAR, and AI4EOSC are:
 
 * `Node-RED <https://nodered.org/>`__ is an open-source visual programming tool.


### PR DESCRIPTION
Included direct links to the relevant README files in the ai4-compose repository for both Elyra and Node-RED/FlowFuse tutorials. This provides users with quick access to example pipelines and supporting materials.

Please, before the PR review, build the documentation and fix the warnings that
may have arisen from your modifications (some warnings might be unrelated to your
modifications though):

```bash
cd ai4-docs
make hmtl

# /***.rst:33: WARNING: blabla
# /***.rst:36: WARNING: blabla
```

If you upload new images as part of your modifications, make sure
[to compress them](https://www.iloveimg.com/compress-image/compress-png).

When you feel your PR is ready, tag [IgnacioHeredia](https://github.com/IgnacioHeredia)
as a reviewer.
