### PR TITLE
docs: clarify optional use of token file path and workspace organization

### DIFF
--- a/source/howtos/pipelines/elyra.rst
+++ b/source/howtos/pipelines/elyra.rst
@@ -54,6 +54,11 @@ For additional information on using EGI Notebooks, refer to the
 To get started, you will need to clone the repository that contains the example files
 for Elyra and OSCAR services: https://github.com/ai4os/ai4-compose
 
+As a good practice to keep your workspace organized, you may first create a dedicated folder 
+(for example, called ``tutorial``) inside your home directory in the EGI Notebooks environment.
+You can then clone the repository inside this folder.  
+This is optional but recommended to avoid clutter in your main workspace.
+
 You can use the Elyra git tool on the left side panel to clone the repository in the
 EGI Notebooks environment.
 This repository contains various examples, including those for Elyra, such as Cowsay,
@@ -83,7 +88,7 @@ To set up an OSCAR client, obtain the OSCAR endpoint. For AI4EOSC, the endpoint 
 
 The ID parameter is optional.
 
-By default, the EGI notebook assigns a token automatically. However, if you cannot retrieve a token from an EGI notebook, you need to generate a refresh token from the EGI token page:
+By default, the EGI notebook assigns a token automatically. However, if you cannot retrieve a token from the EGI notebook environment, you need to generate a refresh token from the EGI token page:
 
 `EGI Check-in Token Portal <https://aai.egi.eu/token>`__
 
@@ -99,7 +104,7 @@ Follow these steps to generate a refresh token:
 
 3. Copy the generated refresh token.
 
-   .. image:: /_static/images/elyra/egi_token_3.png
+Note: providing a token file path is optional, as the setup client node (also called EGI Token node) can extract the token automatically from the Jupyter notebook environment. Use the token file path only if you explicitly generated and want to provide a refresh token.
 
 Once the client is set up, you can seamlessly integrate OSCAR nodes into your workflow.
 
@@ -110,7 +115,7 @@ Before running any example, ensure your OSCAR client is properly configured. You
 
 - **Endpoint**: The URL of the OSCAR inference service.
 - **ID (optional)**: The identifier for the OSCAR service.
-- **Token file path**: The location of the refresh token, if applicable.
+- **Token file path (optional)**: The location of the refresh token, if applicable.
 
 Once configured, you can execute workflows and use OSCAR nodes within your pipeline.
 


### PR DESCRIPTION
- Added recommendation to create a dedicated folder (e.g., "tutorial") before cloning the repository in EGI Notebooks, to keep the workspace organized.
- Clarified in section 2.2 that the token file path is optional since the OSCAR node can extract the token from the Jupyter environment.
- Marked the token file path as optional also in section 2.3 for consistency.

Please, before the PR review, build the documentation and fix the warnings that
may have arisen from your modifications (some warnings might be unrelated to your
modifications though):

```bash
cd ai4-docs
make hmtl

# /***.rst:33: WARNING: blabla
# /***.rst:36: WARNING: blabla
```

If you upload new images as part of your modifications, make sure
[to compress them](https://www.iloveimg.com/compress-image/compress-png).

When you feel your PR is ready, tag [IgnacioHeredia](https://github.com/IgnacioHeredia)
as a reviewer.
